### PR TITLE
Add TMDbHelper.ListItem.Status Localization string

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -1026,10 +1026,15 @@
         <value condition="Skin.HasSetting(DisableOverlayColor)">$LOCALIZE[1223]</value>
     </variable>
 
-    <variable name="Label_Info_NextAired_Status">
-        <value condition="!String.IsEmpty(Window(Home).Property(TMDBHelper.ListItem.Status))">$INFO[Window(Home).Property(TMDBHelper.ListItem.Status)]</value>
-    </variable>
-
+	<variable name="Label_Info_NextAired_Status">
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),Returning Series)">$LOCALIZE[31861]</value>	<!-- Returning Series -->
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),Planned)">$LOCALIZE[31862]</value> <!-- Planned -->
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),In Production)">$LOCALIZE[31863]</value> <!-- In Production -->
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),Ended)">$LOCALIZE[31864]</value> <!-- Ended -->
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),Canceled)">$LOCALIZE[31865]</value> <!-- Canceled -->
+		<value condition="String.Contains(Window(Home).Property(TMDbHelper.ListItem.Status),Pilot)">$LOCALIZE[31866]</value> <!-- Pilot -->
+	</variable>
+	
     <variable name="Label_Info_NextAired_Details">
         <value condition="!String.IsEmpty(Window(Home).Property(TMDBHelper.ListItem.Next_Aired.Name))">$INFO[Window(Home).Property(TMDBHelper.ListItem.Next_Aired),,   -   ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Next_Aired.Name),,  ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Next_Aired.Date),,  ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Next_Aired.Day)]</value>
         <value condition="!String.IsEmpty(Window(Home).Property(TMDBHelper.ListItem.LastEpisode.Label))">$INFO[Window(Home).Property(TMDBHelper.ListItem.Last_Aired),,   -   ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Last_Aired.Name),,  ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Last_Aired.Date),,  ]$INFO[Window(Home).Property(TMDBHelper.ListItem.Last_Aired.Day)]</value>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -4182,3 +4182,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -4182,3 +4182,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -4182,3 +4182,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""

--- a/language/resource.language.es_es/strings.po
+++ b/language/resource.language.es_es/strings.po
@@ -4182,3 +4182,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -4183,3 +4183,33 @@ msgstr "Casa e giardino"
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr "Serie rinnovata"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr "Programmata"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr "In produzione"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr "Terminata"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr "Cancellata"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr "Pilota"

--- a/language/resource.language.nl_nl/strings.po
+++ b/language/resource.language.nl_nl/strings.po
@@ -4183,3 +4183,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""

--- a/language/resource.language.pt_br/strings.po
+++ b/language/resource.language.pt_br/strings.po
@@ -4182,3 +4182,33 @@ msgstr ""
 msgctxt "#31860"
 msgid "Reality"
 msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31861"
+msgid "Returning Series"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31862"
+msgid "Planned"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31863"
+msgid "In Production"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31864"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31865"
+msgid "Canceled"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31866"
+msgid "Pilot"
+msgstr ""


### PR DESCRIPTION
I add the localization string for TV Series status.
I ask to tmdbhelper owner and He tell me that the best is add to skin.

Here the old
![122684785-e431b900-d207-11eb-959c-92f59c67010f](https://user-images.githubusercontent.com/68690475/122799424-00922c00-d2c2-11eb-8047-0e37761a40fa.jpg)

Here the new (Italian translation but can be for any language)
![Immagine](https://user-images.githubusercontent.com/68690475/122799469-0f78de80-d2c2-11eb-8828-f1b9283ad778.jpg)


The status of series are only 6

Returning Series 
Planned
In Production
Ended
Canceled
Pilot

I take it from TMDB Api


With this commit I think the skin is 100% localized