### PR TITLE
Fix4 landscape text label

### DIFF
--- a/1080i/Includes_WidgetMods.xml
+++ b/1080i/Includes_WidgetMods.xml
@@ -741,7 +741,7 @@
           <bottom>10</bottom>
           <height>45</height>
           <width>90</width>
-          <texture background="true" colordiffuse="99FF0000" flipy="true">diffuse/halfbox.png</texture>
+          <texture background="true" colordiffuse="99000000" flipy="true">diffuse/halfbox.png</texture>
         </control>
         <control type="textbox">
           <bottom>-10</bottom>

--- a/1080i/Includes_WidgetMods.xml
+++ b/1080i/Includes_WidgetMods.xml
@@ -745,7 +745,7 @@
         </control>
         <control type="textbox">
           <bottom>-15</bottom>
-          <left>16</left>
+          <left>10</left>
           <height>60</height>
           <width>90</width>
           <label>[I]$INFO[ListItem.Season, S,: ]$INFO[ListItem.Episode,E, ][/I]</label>

--- a/1080i/Includes_WidgetMods.xml
+++ b/1080i/Includes_WidgetMods.xml
@@ -744,9 +744,9 @@
           <texture background="true" colordiffuse="99000000" flipy="true">diffuse/halfbox.png</texture>
         </control>
         <control type="textbox">
-          <bottom>-10</bottom>
-          <left>4</left>
-          <height>55</height>
+          <bottom>-15</bottom>
+          <left>16</left>
+          <height>60</height>
           <width>90</width>
           <label>[I]$INFO[ListItem.Season, S,: ]$INFO[ListItem.Episode,E, ][/I]</label>
           <textcolor>white</textcolor>

--- a/1080i/Includes_WidgetMods.xml
+++ b/1080i/Includes_WidgetMods.xml
@@ -741,7 +741,16 @@
           <bottom>10</bottom>
           <height>45</height>
           <width>90</width>
+          <texture background="true" colordiffuse="99FF0000" flipy="true">diffuse/halfbox.png</texture>
+          <visible>!Skin.HasSetting(DisableAuraHomeLayout)</visible>
+        </control>
+        <control type="image">
+          <left>0</left>
+          <bottom>10</bottom>
+          <height>45</height>
+          <width>90</width>
           <texture background="true" colordiffuse="99000000" flipy="true">diffuse/halfbox.png</texture>
+          <visible>Skin.HasSetting(DisableAuraHomeLayout)</visible>
         </control>
         <control type="textbox">
           <bottom>-15</bottom>


### PR DESCRIPTION
### Color Changes for Netflix Homestyle **ONLY**:

From:
![2022-02-21 05_12_08-Greenshot](https://user-images.githubusercontent.com/17692472/155064299-c35a72f6-0ac3-48b2-8dd3-639c5bafbc4f.png)


***************************************************

To;
![2022-02-21 05_11_34-Greenshot](https://user-images.githubusercontent.com/17692472/155064681-b47df15c-031f-49af-8004-da58acf8ead4.png)


***************************************************
### Text Location Changes for BOTH Homestyles

From:
**Netflix Homestyle**
![2022-02-21 20_16_13-Greenshot](https://user-images.githubusercontent.com/17692472/155064695-eb85c1ba-eb0c-4ef7-acaf-d42b208bfb6f.png)




***************************************************

To:
**Netflix Homestyle**
![2022-02-21 20_14_36-Greenshot](https://user-images.githubusercontent.com/17692472/155064584-03bd7bc4-0e91-401a-b72f-e8f9bf4828e8.png)


***************************************************

From:
**Aura Homestyle**
![2022-02-21 22_13_09-Greenshot](https://user-images.githubusercontent.com/17692472/155073558-5fdcfaaa-188d-45ae-bc69-dc919126c822.png)


***************************************************

To:
**Aura Homestyle**
![2022-02-21 22_08_05-Greenshot](https://user-images.githubusercontent.com/17692472/155073261-9b7052c6-a8a8-41d4-852d-ecd6ebf8c95c.png)


***************************************************

I do see a potential problem with this, in that TV Shows with 3+ digit numbers(S100,e100) would look weird and probably touch the edge of the box or go outside of it. Although I don't know of any shows that do, Simpsons is the longest that comes to mind and their at 33 seasons with 20 episodes each'ish, so still 2 digit. But I would assume there is some obscure something with 100+ seasons but it would be doubtful that it also has 100+ episodes. but I feel like I should mention it. 